### PR TITLE
Permit urls with port numbers that don't have 4 digits

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -33,7 +33,7 @@
 #' # Error in valid_url(url) : invalid URL to Elasticsearch cluster
 #' }
 valid_url <- function(url) {
-  if (grepl("http://", url) & grepl(":[0-9][0-9][0-9][0-9]", url) & !(substr(url, nchar(url), nchar(url)) == "/")) {
+  if (grepl("http://", url) & grepl(":[0-9][0-9]+", url) & !(substr(url, nchar(url), nchar(url)) == "/")) {
     return(TRUE)
   } else {
     stop("invalid URL to Elasticsearch cluster")


### PR DESCRIPTION
Alters `valid_url` to permit port numbers that have 2 or more digits. The prior version throws an error using, e.g., port 80 or port 443, which are in common use.