### PR TITLE
Enable reverse proxy support for elasticsearchr

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -33,7 +33,7 @@
 #' # Error in valid_url(url) : invalid URL to Elasticsearch cluster
 #' }
 valid_url <- function(url) {
-  if (grepl("https?://", url) & grepl(":[0-9][0-9]+", url) & !(substr(url, nchar(url), nchar(url)) == "/")) {
+  if (grepl("https?://", url)) {
     return(TRUE)
   } else {
     stop("invalid URL to Elasticsearch cluster")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -37,14 +37,6 @@ test_that('valid_url identifies invalid URLs to Elasticsearch rescources - missi
 })
 
 
-test_that('valid_url identifies invalid URLs to Elasticsearch rescources - missing port number', {
-  # arrange
-  url <- "http://localhost"
-
-  # act & assert
-  expect_error(valid_url(url))
-})
-
 test_that('valid_url identifies valid ssl URLs to Elasticsearch resources', {
   #arrange
   url <- "https://localhost:9200"


### PR DESCRIPTION
Modified the valid_url function to allow elasticsearchr to be used in a reverse-proxy environment (e.g. as an enterprise managed service).

These changes were made in relation to issue https://github.com/AlexIoannides/elasticsearchr/issues/41 

Changes were:
 - Removed "port number" requirement and trailing slash exclusion from valid_url function
 - Removed test for "port number" from test suite