### PR TITLE
Actualize Inc.'s fix for for issue #28

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
+^Meta$
+^doc$
 ^CRAN-RELEASE$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+Meta
+doc
 .Rproj.user
 .Rhistory
 .RData

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,10 +15,11 @@ BugReports: https://github.com/alexioannides/elasticsearchr/issues
 LazyData: TRUE
 Imports:
     httr,
-    jsonlite
+    jsonlite,
+    dplyr
 Suggests:
     knitr,
     testthat,
     rmarkdown
 VignetteBuilder: knitr
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: elasticsearchr
 Type: Package
-Version: 0.3.0
+Version: 0.3.1
 Title: A Lightweight Interface for Interacting with Elasticsearch from R
-Date: 2019-02-22
+Date: 2019-07-26
 Author: Alex Ioannides
 Maintainer: Alex Ioannides <alex.ioannides@yahoo.co.uk>
 Description: A lightweight R interface to 'Elasticsearch' - a NoSQL search-engine and 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: elasticsearchr
 Type: Package
 Version: 0.3.1
 Title: A Lightweight Interface for Interacting with Elasticsearch from R
-Date: 2019-07-26
+Date: 2019-07-28
 Author: Alex Ioannides
 Maintainer: Alex Ioannides <alex.ioannides@yahoo.co.uk>
 Description: A lightweight R interface to 'Elasticsearch' - a NoSQL search-engine and 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,3 +23,4 @@ Suggests:
     rmarkdown
 VignetteBuilder: knitr
 RoxygenNote: 6.1.1
+Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# elasticsearchr 0.3.1
+
+* Changed back-end to use dplyr::bind_rows as opposed to do.call(rbind) to handle NAs consistently.
+
+
 # elasticsearchr 0.3.0
 
 * Added support for source filtering with the `select_fields` function.

--- a/R/api.R
+++ b/R/api.R
@@ -1,4 +1,4 @@
-# Copyright 2016 Alex Ioannides
+# Copyright 2016-2019 Alex Ioannides
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/R/api.R
+++ b/R/api.R
@@ -346,7 +346,7 @@ list_indices <- function() {
       message(paste0("... ", rescource$index, " has been deleted"))
     } else {
       api_call_payload <- '{"query": {"match_all": {}}}'
-      doc_type_ids <- as.vector(scroll_search(rescource, api_call_payload, extract_id_results))
+      doc_type_ids <- scroll_search(rescource, api_call_payload, extract_id_results)$id
       metadata <- create_metadata("delete", rescource$index, rescource$doc_type, doc_type_ids)
       deletions_file <- create_bulk_delete_file(metadata)
       response <- httr::PUT(url = rescource$cluster_url,

--- a/R/elasticsearchr.R
+++ b/R/elasticsearchr.R
@@ -1,4 +1,4 @@
-# Copyright 2016 Alex Ioannides
+# Copyright 2016-2019 Alex Ioannides
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/R/mappings.R
+++ b/R/mappings.R
@@ -1,4 +1,4 @@
-# Copyright 2016 Alex Ioannides
+# Copyright 2016-2019 Alex Ioannides
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,4 @@
-# Copyright 2016 Alex Ioannides
+# Copyright 2016-2019 Alex Ioannides
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/R/utils.R
+++ b/R/utils.R
@@ -401,7 +401,7 @@ scroll_search <- function(rescource, api_call_payload, extract_function = extrac
     }
   }
 
-  do.call(rbind, scroll_results)
+  as.data.frame(dplyr::bind_rows(scroll_results), stringsAsFactors = FALSE)
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -437,9 +437,9 @@ extract_aggs_results <- function(response) {
 
 #' @rdname extract_query_results
 extract_id_results <- function(response) {
-  df <- jsonlite::fromJSON(httr::content(response, as = 'text'))$hits$hits$`_id`
-  if (length(df) == 0) stop("no ids returned")
-  df
+  ids <- jsonlite::fromJSON(httr::content(response, as = 'text'))$hits$hits$`_id`
+  if (length(ids) == 0) stop("no ids returned")
+  data.frame(id = ids)
 }
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- [![codecov](https://codecov.io/github/alexioannides/elasticsearchr/branch/master/graphs/badge.svg)](https://codecov.io/github/alexioannides/elasticsearchr) -->
 [![Build Status](https://travis-ci.org/AlexIoannides/elasticsearchr.svg?branch=master)](https://travis-ci.org/AlexIoannides/elasticsearchr) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/AlexIoannides/elasticsearchr?branch=master&svg=true)](https://ci.appveyor.com/project/AlexIoannides/elasticsearchr) [![cran version](http://www.r-pkg.org/badges/version/elasticsearchr)](https://cran.r-project.org/package=elasticsearchr) [![rstudio mirror downloads](http://cranlogs.r-pkg.org/badges/grand-total/elasticsearchr)](https://github.com/metacran/cranlogs.app)
 
-- built and tested using Elasticsearch v2.x, v5.x, v6.x.
+- built and tested using Elasticsearch v2.x, v5.x, v6.x and v7.x.
 
 ![][esr_img]
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,8 @@
 ## Test environments
-* local OS X install, R 3.5.2
-* Ubuntu 14.04.5 LTS (on travis-ci), R version 3.5.2 (2017-01-27)
-* Windows Server 2012 R2 x64 (build 9600) (on AppVeyor), R version 3.5.2 Patched (2019-02-19 r76133)
+
+* local OS X install, R 3.6.1
+* Ubuntu 14.04.5 LTS (on travis-ci), R version 3.6.1 (2017-01-27)
+* Windows Server 2012 R2 x64 (build 9600) (on AppVeyor), R version 3.6.1 Patched (2019-07-24 r76883)
 
 ## R CMD check results
 

--- a/tests/testthat/helper-elasticsearch_test_data.R
+++ b/tests/testthat/helper-elasticsearch_test_data.R
@@ -1,4 +1,4 @@
-# Copyright 2016 Alex Ioannides
+# Copyright 2016-2019 Alex Ioannides
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -1,4 +1,4 @@
-# Copyright 2016 Alex Ioannides
+# Copyright 2016-2019 Alex Ioannides
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,4 +1,4 @@
-# Copyright 2016 Alex Ioannides
+# Copyright 2016-2019 Alex Ioannides
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Uses `bind_rows` from the `dplyr` package as opposed to the native `do.call` to fix the issues highlighted in #28.