### PR TITLE
list_fields() bug fix ES:7.4.0

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -186,7 +186,7 @@ list_fields <- function() {
 
   process_response <- function(response) {
     index_mapping <- httr::content(response, as = "parsed")
-    fields <- names(index_mapping[[1]]$mappings$data$properties)
+    fields <- names(index_mapping[[1]]$mappings$properties)
     fields
   }
 


### PR DESCRIPTION
Prb: cannot see list_fields() results, got NULL everytime.
Sol: Change only the path to the result, linked to Elasticsearch 7.4.0